### PR TITLE
Handle no previous/next

### DIFF
--- a/rehive/__init__.py
+++ b/rehive/__init__.py
@@ -5,4 +5,4 @@ __email__ = 'connor@rehive.com'
 
 
 from .rehive import Rehive
-from .api import APIException
+from .api import APIException, NoPaginationException, NoNextException, NoPreviousException

--- a/rehive/api/__init__.py
+++ b/rehive/api/__init__.py
@@ -1,1 +1,1 @@
-from .exception import APIException
+from .exception import APIException, NoPaginationException, NoNextException, NoPreviousException

--- a/rehive/api/exception.py
+++ b/rehive/api/exception.py
@@ -6,3 +6,21 @@ class APIException(Exception):
         self.status_code = status_code
         if data is not None:
             self.data = data
+
+
+class NoPaginationException(Exception):
+    def __init__(self):
+
+        super(NoPaginationException, self).__init__()
+
+
+class NoNextException(NoPaginationException):
+    def __init__(self):
+
+        super(NoNextException, self).__init__()
+
+
+class NoPreviousException(NoPaginationException):
+    def __init__(self):
+
+        super(NoPreviousException, self).__init__()


### PR DESCRIPTION
With this change errors will now be thrown for users calling `get_next` or `get_previous` for resources were the server returns `null`. 

We will need to update the docs and check with everyone using the SDK that it will not impact there services as they could be relying on the old broken logic which would just call the base URL again.