### PR TITLE
Fixing NameError in admin_resources.py

### DIFF
--- a/rehive/api/resources/admin_resources.py
+++ b/rehive/api/resources/admin_resources.py
@@ -145,10 +145,10 @@ class APIAdminMobiles(ResourceList):
     def __init__(self, client, endpoint, filters=None):
         super(APIAdminMobiles, self).__init__(client, endpoint, filters)
 
-    def create(self, user, number, **kwargs):
+    def create(self, user, mobile, **kwargs):
         data = {
             'user': user,
-            'email': email
+            'mobile': mobile
         }
         return self.post(data, **kwargs)
 


### PR DESCRIPTION
Fixing `NameError: name 'email' is not defined` when calling `self.rehive_api.admin.users.mobiles.create`.