### PR TITLE
Add session_duration to login functionality.

### DIFF
--- a/rehive/api/resources/auth_resources.py
+++ b/rehive/api/resources/auth_resources.py
@@ -16,13 +16,13 @@ class AuthResources(Resource, ResourceCollection):
         super(AuthResources, self).__init__(client, self.endpoint)
         self.create_resources(self.resources)
 
-    def login(self, user, company, password):
+    def login(self, user, company, password, **kwargs):
         data = {
             "user": user,
             "company": company,
             "password": password,
         }
-        response = self.post(data, 'login')
+        response = self.post(data, 'login', **kwargs)
         return response
 
     def register(self,


### PR DESCRIPTION
The login functionality doesn't currently accept `session_duration`. I have added a `**kwargs` argument to the `login` method to allow for an optional `session_duration` field to be included.