### PR TITLE
Update auth_resources.py

### DIFF
--- a/rehive/api/resources/auth_resources.py
+++ b/rehive/api/resources/auth_resources.py
@@ -26,16 +26,12 @@ class AuthResources(Resource, ResourceCollection):
         return response
 
     def register(self,
-                 first_name,
-                 last_name,
                  email,
                  company,
                  password1,
                  password2,
                  **kwargs):
         data = {
-           "first_name": first_name,
-           "last_name": last_name,
            "email": email,
            "company": company,
            "password1": password1,


### PR DESCRIPTION
`first_name` and `last_name` are not required when registering as a new user (https://api.docs.rehive.com/#register), but the Python SDK still requires these fields. By removing these fields, `first_name` and `last_name` will no longer be required and the SDK will be inline with the general Rehive APIs.