### PR TITLE
Bug fix when creating an account currency for a user.

### DIFF
--- a/rehive/api/resources/admin_resources.py
+++ b/rehive/api/resources/admin_resources.py
@@ -51,15 +51,11 @@ class APIAdminCurrencies(ResourceList, ResourceCollection):
         )
         super(APIAdminCurrencies, self).__init__(client, endpoint, filters)
 
-    def create(self, code, description, symbol, unit, divisibility):
+    def create(self, currency, **kwargs):
         data = {
-            "code": code,
-            "description": description,
-            "symbol": symbol,
-            "unit": unit,
-            "divisibility": divisibility
+            "currency": currency
         }
-        response = self.post(data)
+        response = self.post(data, **kwargs)
         return response
 
     @classmethod


### PR DESCRIPTION
When trying to add an account currency for a user via the endpoint via the Python SDK (https://api.docs.rehive.com/?shell#create-account-currency148)
```python
response = self.rehive_api.admin.accounts.obj(reference).currencies.create(
            currency=currency
        )
```

we got the following error: `TypeError: create() got an unexpected keyword argument 'currency'`. 

We validated that the docs are corrected by making the API call using the shell. 

After looking at the code above, the issue was obvious and I've made the changes in this PR.